### PR TITLE
(fix) Build with Volume Manual

### DIFF
--- a/docs/building/with-network-volume.md
+++ b/docs/building/with-network-volume.md
@@ -55,10 +55,11 @@ cd /workspace/text-generation-webui
 python3 download-model.py TheBloke/Synthia-34B-v1.2-GPTQ \
   --output /workspace/text-generation-webui/models
 ```
-Everything should now be installed on your Network Volume and it
+## Final steps
+1. Everything should now be installed on your Network Volume and it
    should be safe to terminate the pod.
-Sign up for a Docker hub account if you don't already have one.
-Build the Docker image on your local machine and push to Docker hub:
+2. Sign up for a Docker hub account if you don't already have one.
+3. Build the Docker image on your local machine and push to Docker hub:
 ```bash
 docker build -t dockerhub-username/runpod-worker-oobabooga:latest -f Dockerfile.Network_Volume .
 docker login

--- a/docs/building/with-network-volume.md
+++ b/docs/building/with-network-volume.md
@@ -55,12 +55,12 @@ cd /workspace/text-generation-webui
 python3 download-model.py TheBloke/Synthia-34B-v1.2-GPTQ \
   --output /workspace/text-generation-webui/models
 ```
-9. Everything should now be installed on your Network Volume and it
+Everything should now be installed on your Network Volume and it
    should be safe to terminate the pod.
-10. Sign up for a Docker hub account if you don't already have one.
-11. Build the Docker image on your local machine and push to Docker hub:
+Sign up for a Docker hub account if you don't already have one.
+Build the Docker image on your local machine and push to Docker hub:
 ```bash
-docker build -t dockerhub-username/runpod-worker-oobabooga:1.0.0 -f Dockerfile.Network_Volume .
+docker build -t dockerhub-username/runpod-worker-oobabooga:latest -f Dockerfile.Network_Volume .
 docker login
-docker push dockerhub-username/runpod-worker-oobabooga:1.0.0
+docker push dockerhub-username/runpod-worker-oobabooga:latest
 ```


### PR DESCRIPTION
Update the manual in order to avoid ambiguity in which steps are required in manual installation, auto-installation, and both cases. Update the default image tag to standard of "latest", which RunPod seems to pull in Serverless worker if tag was omitted in at "Container Image" field.